### PR TITLE
Fix karma set-up

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,8 +4,8 @@ module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: [ 'jasmine' ],
-    files: [ { pattern: 'spec-bundle.js', watched: false } ],
-    preprocessors: { 'spec-bundle.js': ['webpack', 'sourcemap'] },
+    files: [ { pattern: 'spec.bundle.js', watched: false } ],
+    preprocessors: { 'spec.bundle.js': ['webpack', 'sourcemap'] },
     webpack: webpackConfig,
     webpackServer: { noInfo:false },
     reporters: [ 'spec' ],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
+    "awesome-typescript-loader": "^2.1.1",
     "compression-webpack-plugin": "^0.3.1",
     "html-webpack-plugin": "^2.22.0",
     "jasmine-core": "^2.4.1",
@@ -33,12 +34,14 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.1",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.8.0",
     "phantomjs-prebuilt": "^2.1.12",
     "remap-istanbul": "^0.6.4",
     "source-map-loader": "^0.1.5",
     "systemjs": "^0.19.36",
+    "ts-helpers": "^1.1.1",
     "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
     "typings": "^1.3.2",

--- a/spec.bundle.js
+++ b/spec.bundle.js
@@ -1,5 +1,36 @@
-require('core-js');
+/*
+ * When testing with webpack and ES6, we have to do some extra
+ * things to get testing to work right. Because we are gonna write tests
+ * in ES6 too, we have to compile those as well. That's handled in
+ * karma.conf.js with the karma-webpack plugin. This is the entry
+ * file for webpack test. Just like webpack will create a bundle.js
+ * file for our client, when we run test, it will compile and bundle them
+ * all here! Crazy huh. So we need to do some setup
+ */
+Error.stackTraceLimit = Infinity;
+
+require('core-js/es6');
+require('core-js/es7/reflect');
+
+// Typescript emit helpers polyfill
+require('ts-helpers');
+
+// ZoneJS Stuff
 require('zone.js/dist/zone');
+require('zone.js/dist/long-stack-trace-zone');
+require('zone.js/dist/jasmine-patch');
+require('zone.js/dist/async-test');
+require('zone.js/dist/fake-async-test');
+require('zone.js/dist/sync-test');
+
+// AngularJS Stuff to set environment ready
+var testing = require('@angular/core/testing');
+var browser = require('@angular/platform-browser-dynamic/testing');
+
+testing.setBaseTestProviders(
+  browser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
+  browser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS
+);
 
 var testContext = require.context('./src', true, /\.spec\.ts/);
 

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from '@angular/core/testing'
-
 import { AppComponent } from './app/app.component'
 
 describe('AppComponent', () => {

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,9 @@
 {
+  "ambientDependencies": {
+    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#4b36b94d5910aa8a4d20bdcd5bd1f9ae6ad18d3c"
+  },
   "globalDependencies": {
+  	"es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
     "core-js": "registry:dt/core-js#0.0.0+20160725163759"
   }
 }


### PR DESCRIPTION
- [x] Refactor `spec-bundle.js`into `spec.bundle.js` and add some requirements (not needed now but useful for full testing capabilities)
- [x] Add NPM dependencies
- `awesome-typescript-loader` => typescript compiler for webpack
- `karma-sourcemap-loader`=> sourcemap loader for webpack
- `ts-helpers` => typescript polyfills
- [x] Add typings dependecies: `jasmine` && `es6-shim`
  FYI, `ambientDependencies` means that typescript will be aware about jasmine methods
- [x] Remove jasmine import (`it`, `describe`, etc.) ==> ambient dependencies
